### PR TITLE
Add additional headers at authentication actions

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,14 +1,14 @@
 // Predefined fetch function
-export const fetchEndpoint = (data, url) => {
+export const fetchEndpoint = (data, url, headers = {}) => {
   return fetch(
       url,
       {
         method: 'POST',
         credentials: 'same-origin',
-        headers: {
+        headers: Object.assign({
           'Content-Type': 'application/json',
           'Accept': 'application/json',
-        },
+        }, headers),
         body: JSON.stringify(data),
       }
   );

--- a/src/useLogin.js
+++ b/src/useLogin.js
@@ -4,14 +4,14 @@ import {
     preparePublicKeyOptions,
 } from './common';
 
-const useLogin = ({actionUrl = '/login', optionsUrl = '/login/options'}) => {
+const useLogin = ({actionUrl = '/login', optionsUrl = '/login/options', headers = {}}) => {
     return async (data) => {
         const optionsResponse = await fetchEndpoint(data, optionsUrl);
         const json = await optionsResponse.json();
         const publicKey = preparePublicKeyOptions(json);
         const credentials = await navigator.credentials.get({publicKey});
         const publicKeyCredential = preparePublicKeyCredentials(credentials);
-        const actionResponse = await fetchEndpoint(publicKeyCredential, actionUrl);
+        const actionResponse = await fetchEndpoint(publicKeyCredential, actionUrl, headers);
 
         return await actionResponse.json();
     };

--- a/src/useLogin.js
+++ b/src/useLogin.js
@@ -4,8 +4,8 @@ import {
     preparePublicKeyOptions,
 } from './common';
 
-const useLogin = ({actionUrl = '/login', optionsUrl = '/login/options', headers = {}}) => {
-    return async (data) => {
+const useLogin = ({actionUrl = '/login', optionsUrl = '/login/options'}) => {
+    return async (data, headers = {}) => {
         const optionsResponse = await fetchEndpoint(data, optionsUrl);
         const json = await optionsResponse.json();
         const publicKey = preparePublicKeyOptions(json);

--- a/src/useRegistration.js
+++ b/src/useRegistration.js
@@ -11,7 +11,7 @@ const useRegistration = ({actionUrl = '/register', optionsUrl = '/register/optio
         const publicKey = preparePublicKeyOptions(json);
         const credentials = await navigator.credentials.create({publicKey});
         const publicKeyCredential = preparePublicKeyCredentials(credentials);
-        const actionResponse = await fetchEndpoint(publicKeyCredential, actionUrl);
+        const actionResponse = await fetchEndpoint(publicKeyCredential, actionUrl, headers);
 
         return await actionResponse.json();
     };

--- a/src/useRegistration.js
+++ b/src/useRegistration.js
@@ -4,7 +4,7 @@ import {
     preparePublicKeyOptions,
 } from './common';
 
-const useRegistration = ({actionUrl = '/register', optionsUrl = '/register/options'}) => {
+const useRegistration = ({actionUrl = '/register', optionsUrl = '/register/options', headers = {}}) => {
     return async (data) => {
         const optionsResponse = await fetchEndpoint(data, optionsUrl);
         const json = await optionsResponse.json();

--- a/src/useRegistration.js
+++ b/src/useRegistration.js
@@ -4,8 +4,8 @@ import {
     preparePublicKeyOptions,
 } from './common';
 
-const useRegistration = ({actionUrl = '/register', optionsUrl = '/register/options', headers = {}}) => {
-    return async (data) => {
+const useRegistration = ({actionUrl = '/register', optionsUrl = '/register/options'}) => {
+    return async (data, headers = {}) => {
         const optionsResponse = await fetchEndpoint(data, optionsUrl);
         const json = await optionsResponse.json();
         const publicKey = preparePublicKeyOptions(json);


### PR DESCRIPTION
The user can easily add additional headers when pushing credentials to the authentication action routes.

```javascript
import {useRegistration, useLogin} from 'webauthn-helper';

const register = useRegistration({
    actionUrl: '/api/register',
    optionsUrl: '/api/register/options',
});

register({
    username: 'FOO4',
    displayName: 'baR'
}, {
    'X-Foo': 'foo'
})
    .then((response)=> console.log('Registration success'))
    .catch((error)=> console.log('Registration failure'));

const login = useLogin({
    loginUrl: '/api/login',
    loginOptions: '/api/login/options'
});

login({
    username: 'john.doe'
}, {
    'X-Bar': 'bar',
})
    .then((response)=> console.log('Login success'))
    .catch((error)=> console.log('Login failure'));


```

These headers are only used for the action request, not the option request. This allows the server to run logic based on a header value instead of meddling with the body (which contains the WebAuthn data).