### PR TITLE
fix incorrect named params in json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ register({
 import {useLogin} from '@web-auth/webauthn-helper';
 
 const login = useLogin({
-    loginUrl: '/api/login',
-    loginOptions: '/api/login/options'
+    actionUrl: '/api/login',
+    optionsUrl: '/api/login/options'
 });
 
 login({


### PR DESCRIPTION
When I (a php dev) was copy and pasting examples to play with them, I hit a roadblock.

On debugging I note that the useLogin function is defined as 

```js
const useLogin = ({actionUrl = '/login2', actionHeader = {}, optionsUrl = '/login/options2'}, optionsHeader = {}) => {
```

yet the documentation example was telling me to use 

```js
useLogin({
    loginUrl: '/api/login',
    loginOptions: '/api/login/options'
})
```

which was not obviously wrong to me (a non js dev), but on changing these to `actionUrl` and `optionsUrl` I was able to make the example work for me 

```js
import {useLogin} from '@web-auth/webauthn-helper';

const login = useLogin({
    actionUrl: '/webauthn/login/action',
    optionsUrl: '/webauthn/login/options'
});

login({
    username: 'john.doe'
})
    .then((response)=> console.log('Login success'))
    .catch((error)=> console.log('Login failure'))
;

```