### PR TITLE
Fix: 'optionsHeader' object parameters not part of objects group

### DIFF
--- a/src/useLogin.js
+++ b/src/useLogin.js
@@ -4,7 +4,7 @@ import {
     preparePublicKeyOptions,
 } from './common';
 
-const useLogin = ({actionUrl = '/login', actionHeader = {}, optionsUrl = '/login/options'}, optionsHeader = {}) => {
+const useLogin = ({actionUrl = '/login', actionHeader = {}, optionsUrl = '/login/options', optionsHeader = {}}) => {
     return async (data) => {
         const optionsResponse = await fetchEndpoint(data, optionsUrl, optionsHeader);
         const json = await optionsResponse.json();

--- a/src/useRegistration.js
+++ b/src/useRegistration.js
@@ -4,7 +4,7 @@ import {
     preparePublicKeyOptions,
 } from './common';
 
-const useRegistration = ({actionUrl = '/register', actionHeader = {}, optionsUrl = '/register/options'}, optionsHeader = {}) => {
+const useRegistration = ({actionUrl = '/register', actionHeader = {}, optionsUrl = '/register/options', optionsHeader = {}}) => {
     return async (data) => {
         const optionsResponse = await fetchEndpoint(data, optionsUrl, optionsHeader);
         const json = await optionsResponse.json();


### PR DESCRIPTION
Ran into this when needing to pass a CSRF-token header